### PR TITLE
Add install target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,3 +99,14 @@ install(TARGETS wincpp EXPORT wincpp
 )
 
 install(FILES ${header_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake" VERSION 1.5.3.6 COMPATIBILITY AnyNewerVersion)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/wincppConfig.cmake" "include(\${CMAKE_CURRENT_LIST_DIR}/wincppTargets.cmake)\n")
+install(FILES
+	    "${CMAKE_CURRENT_BINARY_DIR}/wincppConfig.cmake"
+	        "${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake"
+		    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wincpp
+)
+
+install(EXPORT wincppTargets FILE wincppTargets.cmake NAMESPACE wincpp:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wincpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,7 +106,7 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/wincppConfig.cmake" "include(\${CMAKE_CU
 install(FILES
 	    "${CMAKE_CURRENT_BINARY_DIR}/wincppConfig.cmake"
 	        "${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake"
-		    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wincpp
+		DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/wincpp
 )
 
 install(EXPORT wincpp-export FILE wincppTargets.cmake NAMESPACE wincpp:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wincpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,7 @@ install(TARGETS wincpp _wincpp_core EXPORT wincpp-export
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wincpp"
 )
 
-install(DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../include" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wincpp")
+install(DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../include" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake" VERSION 1.5.3.6 COMPATIBILITY AnyNewerVersion)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(_wincpp_core SYSTEM INTERFACE
 )
 
 # Add the library to the project
-add_library(wincpp STATIC)
+add_library(wincpp)
 
 # Link the library to the core
 target_link_libraries(wincpp INTERFACE _wincpp_core)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,7 +91,7 @@ target_include_directories(wincpp PRIVATE ${include_dir})
 
 include(GNUInstallDirs)
 # Install wincpp library
-install(TARGETS wincpp EXPORT wincpp
+install(TARGETS wincpp EXPORT wincpp-export
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -109,4 +109,4 @@ install(FILES
 		    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wincpp
 )
 
-install(EXPORT wincppTargets FILE wincppTargets.cmake NAMESPACE wincpp:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wincpp)
+install(EXPORT wincpp-export FILE wincppTargets.cmake NAMESPACE wincpp:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wincpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_path(SET include_dir "${CMAKE_CURRENT_SOURCE_DIR}/../include")
-
+include(GNUInstallDirs)
 # Add the header files to the project
 set(header_files 
 	"${include_dir}/wincpp/process.hpp"
@@ -42,7 +42,7 @@ target_sources(_wincpp_core INTERFACE $<BUILD_INTERFACE:${header_files}>)
 # Add the include directories
 target_include_directories(_wincpp_core SYSTEM INTERFACE 
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/wincpp>
 )
 
 # Add the library to the project
@@ -89,16 +89,15 @@ target_sources(wincpp PRIVATE
 # Add the include directory to the project
 target_include_directories(wincpp PRIVATE ${include_dir})
 
-include(GNUInstallDirs)
 # Install wincpp library
 install(TARGETS wincpp _wincpp_core EXPORT wincpp-export
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wincpp"
 )
 
-install(FILES ${header_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${header_files} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wincpp")
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake" VERSION 1.5.3.6 COMPATIBILITY AnyNewerVersion)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,7 @@ install(TARGETS wincpp _wincpp_core EXPORT wincpp-export
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wincpp"
 )
 
-install(DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../include" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../include/wincpp" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake" VERSION 1.5.3.6 COMPATIBILITY AnyNewerVersion)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,7 @@ set(header_files
 # Add the library to the project
 add_library(_wincpp_core INTERFACE)
 # Add the include directory to the project
-target_sources(_wincpp_core INTERFACE ${header_files})
+target_sources(_wincpp_core INTERFACE $<BUILD_INTERFACE:${header_files}>)
 
 # Add the include directories
 target_include_directories(_wincpp_core SYSTEM INTERFACE 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,7 +91,7 @@ target_include_directories(wincpp PRIVATE ${include_dir})
 
 include(GNUInstallDirs)
 # Install wincpp library
-install(TARGETS wincpp EXPORT wincpp-export
+install(TARGETS wincpp _wincpp_core EXPORT wincpp-export
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,7 @@ target_sources(wincpp PRIVATE
 # Add the include directory to the project
 target_include_directories(wincpp PRIVATE ${include_dir})
 
+include(GNUInstallDirs)
 # Install wincpp library
 install(TARGETS wincpp EXPORT wincpp
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,4 +109,4 @@ install(FILES
 		DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/wincpp
 )
 
-install(EXPORT wincpp-export FILE wincppTargets.cmake NAMESPACE wincpp:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wincpp)
+install(EXPORT wincpp-export FILE wincppTargets.cmake NAMESPACE wincpp:: DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/wincpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,7 @@ install(TARGETS wincpp _wincpp_core EXPORT wincpp-export
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wincpp"
 )
 
-install(FILES ${header_files} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wincpp")
+install(DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../include" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wincpp")
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake" VERSION 1.5.3.6 COMPATIBILITY AnyNewerVersion)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(_wincpp_core SYSTEM INTERFACE
 
 # Add the library to the project
 add_library(wincpp)
+set_target_properties(wincpp PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # Link the library to the core
 target_link_libraries(wincpp PUBLIC _wincpp_core)
@@ -110,7 +111,6 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/wincppConfig.cmake"
     "include(\${CMAKE_CURRENT_LIST_DIR}/wincppTargets.cmake)\n"
 )
 
-# 5. Install Config Files to share/wincpp (The vcpkg standard)
 set(wincpp_CONFFILE_DEST "${CMAKE_INSTALL_DATAROOTDIR}/wincpp")
 
 install(FILES
@@ -119,7 +119,6 @@ install(FILES
     DESTINATION ${wincpp_CONFFILE_DEST}
 )
 
-# 6. Install the Export set
 install(EXPORT wincpp-export 
     FILE wincppTargets.cmake 
     NAMESPACE wincpp:: 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ target_include_directories(_wincpp_core SYSTEM INTERFACE
 add_library(wincpp)
 
 # Link the library to the core
-target_link_libraries(wincpp INTERFACE _wincpp_core)
+target_link_libraries(wincpp PUBLIC _wincpp_core)
 
 # Add the source files to the project
 target_sources(wincpp PRIVATE 	
@@ -94,18 +94,34 @@ install(TARGETS wincpp _wincpp_core EXPORT wincpp-export
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wincpp"
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install(DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../include/wincpp" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 include(CMakePackageConfigHelpers)
-write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake" VERSION 1.5.3.6 COMPATIBILITY AnyNewerVersion)
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/wincppConfig.cmake" "include(\${CMAKE_CURRENT_LIST_DIR}/wincppTargets.cmake)\n")
-install(FILES
-	    "${CMAKE_CURRENT_BINARY_DIR}/wincppConfig.cmake"
-	        "${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake"
-		DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/wincpp
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake" 
+    VERSION 1.5.3.6 
+    COMPATIBILITY AnyNewerVersion
 )
 
-install(EXPORT wincpp-export FILE wincppTargets.cmake NAMESPACE wincpp:: DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/wincpp)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/wincppConfig.cmake" 
+    "include(\${CMAKE_CURRENT_LIST_DIR}/wincppTargets.cmake)\n"
+)
+
+# 5. Install Config Files to share/wincpp (The vcpkg standard)
+set(wincpp_CONFFILE_DEST "${CMAKE_INSTALL_DATAROOTDIR}/wincpp")
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/wincppConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/wincppConfigVersion.cmake"
+    DESTINATION ${wincpp_CONFFILE_DEST}
+)
+
+# 6. Install the Export set
+install(EXPORT wincpp-export 
+    FILE wincppTargets.cmake 
+    NAMESPACE wincpp:: 
+    DESTINATION ${wincpp_CONFFILE_DEST}
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,9 +89,12 @@ target_sources(wincpp PRIVATE
 # Add the include directory to the project
 target_include_directories(wincpp PRIVATE ${include_dir})
 
+# Install wincpp library
 install(TARGETS wincpp EXPORT wincpp
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+install(FILES ${header_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,6 @@ set(header_files
 
 # Add the library to the project
 add_library(_wincpp_core INTERFACE)
-
 # Add the include directory to the project
 target_sources(_wincpp_core INTERFACE ${header_files})
 
@@ -89,3 +88,10 @@ target_sources(wincpp PRIVATE
 
 # Add the include directory to the project
 target_include_directories(wincpp PRIVATE ${include_dir})
+
+install(TARGETS wincpp EXPORT wincpp
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/src/memory_factory.cpp
+++ b/src/memory_factory.cpp
@@ -61,7 +61,7 @@ namespace wincpp
             }
             case wincpp::memory_type::remote_t:
             {
-                std::size_t written;
+                SIZE_T written;
 
                 WriteProcessMemory( p->handle->native, reinterpret_cast< void* >( address ), buffer, size, &written );
                 return written;

--- a/src/memory_factory.cpp
+++ b/src/memory_factory.cpp
@@ -24,7 +24,7 @@ namespace wincpp
             }
             case wincpp::memory_type::remote_t:
             {
-                std::size_t read;
+                SIZE_T read;
 
                 if ( !ReadProcessMemory( p->handle->native, reinterpret_cast< void* >( address ), buffer, size, &read ) || read != size )
                     return false;


### PR DESCRIPTION
Adds the cmake install target to install the library onto the local system for use by other projects.
Also fixes an issue where the build would fail on 32 bit systems due to the implicit cast between std::size_t and windows's SIZE_T